### PR TITLE
chore: update CODEOWNERS for dependency files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+* @kinde-starter-kits/giants-kinde
+Gemfile @kinde-starter-kits/sdk-engineers
+**/Gemfile @kinde-starter-kits/sdk-engineers
+Gemfile.lock @kinde-starter-kits/sdk-engineers
+**/Gemfile.lock @kinde-starter-kits/sdk-engineers
+build.gradle @kinde-starter-kits/sdk-engineers
+**/build.gradle @kinde-starter-kits/sdk-engineers
+build.gradle @kinde-starter-kits/sdk-engineers
+**/build.gradle @kinde-starter-kits/sdk-engineers
+package.json @kinde-starter-kits/sdk-engineers
+**/package.json @kinde-starter-kits/sdk-engineers


### PR DESCRIPTION
Automated update to CODEOWNERS so that @kinde-oss/sdk-engineers own dependency definition files and can approve dependency PRs.