### PR TITLE
chore: standardize CODEOWNERS for giants-kinde and sdk-engineers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,14 @@
 * @kinde-starter-kits/giants-kinde
+package-lock.json @kinde-starter-kits/sdk-engineers
+**/package-lock.json @kinde-starter-kits/sdk-engineers
+package.json @kinde-starter-kits/sdk-engineers
+**/package.json @kinde-starter-kits/sdk-engineers
+pnpm-lock.yaml @kinde-starter-kits/sdk-engineers
+**/pnpm-lock.yaml @kinde-starter-kits/sdk-engineers
+
 Gemfile @kinde-starter-kits/sdk-engineers
 **/Gemfile @kinde-starter-kits/sdk-engineers
 Gemfile.lock @kinde-starter-kits/sdk-engineers
 **/Gemfile.lock @kinde-starter-kits/sdk-engineers
 build.gradle @kinde-starter-kits/sdk-engineers
 **/build.gradle @kinde-starter-kits/sdk-engineers
-build.gradle @kinde-starter-kits/sdk-engineers
-**/build.gradle @kinde-starter-kits/sdk-engineers
-package.json @kinde-starter-kits/sdk-engineers
-**/package.json @kinde-starter-kits/sdk-engineers


### PR DESCRIPTION
## Summary
- Set `*` default ownership to `@kinde-starter-kits/giants-kinde`
- Assign `@kinde-starter-kits/sdk-engineers` to npm/pnpm dependency files
- Aligns this repo with the org-wide CODEOWNERS standard used in `react-starter-kit`

## Test plan
- [ ] Verify CODEOWNERS file is present at the expected path
- [ ] Confirm PRs touching `package.json` request review from `sdk-engineers`
- [ ] Confirm other changes request review from `giants-kinde`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated repository ownership and review routing for more consistent maintenance.
  - Consolidated package and dependency-file ownership rules, including support for multiple package ecosystems.
  - Removed duplicate ownership entries.

- **User Impact**
  - No changes to application functionality or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->